### PR TITLE
fix(PET-1098): Fix for infinite connection retries

### DIFF
--- a/kombu/common.py
+++ b/kombu/common.py
@@ -135,7 +135,9 @@ def _maybe_declare(entity, channel):
 
     _ensure_channel_is_bound(entity, channel)
 
-    if channel is None:
+    if channel is None or channel.connection is None:
+        # If this was called from the `ensure()` method then the channel could have been invalidated
+        # and the correct channel was re-bound to the entity by calling the `entity.revive()` method.
         if not entity.is_bound:
             raise ChannelError(
                 f"channel is None and entity {entity} not bound.")


### PR DESCRIPTION
When used in celery kombu fails to reconnect to rabbitmq after it loses connection enough times when task are being processed. Eventually the master process would attempt to connect to rabbitmq and then close the connection after a very brief moment and do that until an error occurred, which would break the infinite loop. This is cloning changes from this PR which is not yet merged: https://github.com/celery/kombu/pull/2275 I have verified that the issue of infinite connection creation is fixed, but other celery problems are still there. It is still an improvement.